### PR TITLE
Add micros method to get microseconds since boot

### DIFF
--- a/mrblib/mrb_esp32_system.rb
+++ b/mrblib/mrb_esp32_system.rb
@@ -1,4 +1,6 @@
 module ESP32
   module System
   end
+  module Timer
+  end
 end

--- a/src/mrb_esp32_system.c
+++ b/src/mrb_esp32_system.c
@@ -48,7 +48,7 @@ mrb_esp32_system_deep_sleep_for(mrb_state *mrb, mrb_value self) {
 
 static mrb_value
 mrb_esp32_esp_timer_get_time(mrb_state *mrb, mrb_value self) {
-  return mrb_fixnum_value(esp_timer_get_time());
+  return mrb_float_value(mrb, esp_timer_get_time());
 }
 
 void

--- a/src/mrb_esp32_system.c
+++ b/src/mrb_esp32_system.c
@@ -5,6 +5,7 @@
 
 #include "esp_system.h"
 #include "esp_sleep.h"
+#include "esp_timer.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -45,6 +46,11 @@ mrb_esp32_system_deep_sleep_for(mrb_state *mrb, mrb_value self) {
   return self;
 }
 
+static mrb_value
+mrb_esp32_esp_timer_get_time(mrb_state *mrb, mrb_value self) {
+  return mrb_fixnum_value(esp_timer_get_time());
+}
+
 void
 mrb_mruby_esp32_system_gem_init(mrb_state* mrb) {
   struct RClass *esp32_module = mrb_define_module(mrb, "ESP32");
@@ -56,6 +62,7 @@ mrb_mruby_esp32_system_gem_init(mrb_state* mrb) {
   mrb_define_module_function(mrb, esp32_system_module, "sdk_version", mrb_esp32_system_sdk_version, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, esp32_system_module, "restart", mrb_esp32_system_restart, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, esp32_system_module, "deep_sleep_for", mrb_esp32_system_deep_sleep_for, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, esp32_system_module, "micros", mrb_esp32_esp_timer_get_time, MRB_ARGS_NONE());
 }
 
 void

--- a/src/mrb_esp32_system.c
+++ b/src/mrb_esp32_system.c
@@ -62,7 +62,10 @@ mrb_mruby_esp32_system_gem_init(mrb_state* mrb) {
   mrb_define_module_function(mrb, esp32_system_module, "sdk_version", mrb_esp32_system_sdk_version, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, esp32_system_module, "restart", mrb_esp32_system_restart, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, esp32_system_module, "deep_sleep_for", mrb_esp32_system_deep_sleep_for, MRB_ARGS_REQ(1));
-  mrb_define_module_function(mrb, esp32_system_module, "micros", mrb_esp32_esp_timer_get_time, MRB_ARGS_NONE());
+
+  struct RClass *esp32_timer_module = mrb_define_module_under(mrb, esp32_module, "Timer");
+
+  mrb_define_module_function(mrb, esp32_timer_module, "get_time", mrb_esp32_esp_timer_get_time, MRB_ARGS_NONE());
 }
 
 void


### PR DESCRIPTION
`ESP32::System.micros` gets microseconds since boot using `esp_timer_get_time()`. Would need to add the `esp_timer` component to the main idf project folder for it to work.