### PR TITLE
Add chip_model method

### DIFF
--- a/src/mrb_esp32_system.c
+++ b/src/mrb_esp32_system.c
@@ -57,21 +57,9 @@ mrb_esp32_get_chip_model(mrb_state *mrb, mrb_value self) {
   esp_chip_info_t info;
   esp_chip_info(&info);
   
-  // The integer in info.model is one of an enum. Values taken from here:
-  // https://github.com/espressif/esp-idf/blob/67552c31dac8cd94fb0d63192a538f4f984c5b6e/components/esp_hw_support/include/esp_chip_info.h#L22C7-L22C7
-  switch (info.model) {
-    // String format matches style used when installing ESP-IDF.
-    case   1: return mrb_str_new_cstr(mrb, "esp32");
-    case   2: return mrb_str_new_cstr(mrb, "esp32s2");
-    case   9: return mrb_str_new_cstr(mrb, "esp32s3");
-    case   5: return mrb_str_new_cstr(mrb, "esp32c3");
-    case  12: return mrb_str_new_cstr(mrb, "esp32c2");
-    case  13: return mrb_str_new_cstr(mrb, "esp32c6");
-    case  16: return mrb_str_new_cstr(mrb, "esp32h2");
-    case  18: return mrb_str_new_cstr(mrb, "esp32p4");
-    case 999: return mrb_str_new_cstr(mrb, "simulator");
-    default:  return mrb_str_new_cstr(mrb, "unknown");
-  }
+  // The integer value in info.model is one of an enum, esp_chip_model_t, found here:
+  // https://github.com/espressif/esp-idf/blob/master/components/esp_hw_support/include/esp_chip_info.h
+  return mrb_fixnum_value(info.model);
 }
 
 void

--- a/src/mrb_esp32_system.c
+++ b/src/mrb_esp32_system.c
@@ -56,9 +56,6 @@ static mrb_value
 mrb_esp32_get_chip_model(mrb_state *mrb, mrb_value self) {
   esp_chip_info_t info;
   esp_chip_info(&info);
-  
-  // The integer value in info.model is one of an enum, esp_chip_model_t, found here:
-  // https://github.com/espressif/esp-idf/blob/master/components/esp_hw_support/include/esp_chip_info.h
   return mrb_fixnum_value(info.model);
 }
 
@@ -79,6 +76,30 @@ mrb_mruby_esp32_system_gem_init(mrb_state* mrb) {
   // ESP32::Timer
   struct RClass *esp32_timer_module = mrb_define_module_under(mrb, esp32_module, "Timer");
   mrb_define_module_function(mrb, esp32_timer_module, "get_time", mrb_esp32_esp_timer_get_time, MRB_ARGS_NONE());
+  
+  // ESP32::Constants
+  struct RClass *constants = mrb_define_module_under(mrb, esp32_module, "Constants");
+  
+  // Pass a C constant through to mruby, defined inside ESP32::Constants.
+  #define define_const(SYM) \
+  do { \
+    mrb_define_const(mrb, constants, #SYM, mrb_fixnum_value(SYM)); \
+  } while (0)
+
+  //
+  // ESP32::System.chip_model returns a constant from the esp_chip_model_t enum:
+  // https://github.com/espressif/esp-idf/blob/master/components/esp_hw_support/include/esp_chip_info.h
+  //
+  // Define constants from the enum in mruby:
+  define_const(CHIP_ESP32);
+  define_const(CHIP_ESP32S2);
+  define_const(CHIP_ESP32S3);
+  define_const(CHIP_ESP32C3);
+  define_const(CHIP_ESP32C2);
+  define_const(CHIP_ESP32C6);
+  define_const(CHIP_ESP32H2);
+  // define_const(CHIP_ESP32P4);
+  define_const(CHIP_POSIX_LINUX);
 }
 
 void


### PR DESCRIPTION
I'm working on ESP32-S2 and ESP32-S3 support for [mruby-esp32-gpio](https://github.com/mruby-esp32/mruby-esp32-gpio) (PR soon). This method allows the mruby script to identify which chip it's running on.